### PR TITLE
Removed duplicate setting

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -5,8 +5,6 @@ server:
   port: 7777
   host: 0.0.0.0 # Use localhost for local development, 0.0.0.0 for external access
 
-max_memories_to_recall: 10
-
 # OpenAI-compatible API configuration
 ai:
   # API endpoint URL (examples):


### PR DESCRIPTION
When setting up the system from scratch, startup will fail because of this duplicate property.