### PR TITLE
expose image prompt error msg

### DIFF
--- a/server.js
+++ b/server.js
@@ -12620,7 +12620,10 @@ async function generateImagePromptFromTemplate(prompts, options = {}) {
         };
 
     } catch (error) {
-        console.error('Error generating image prompt with LLM:', error);
+        const bodyError = error?.response?.data?.error;
+        const message = bodyError?.message || bodyError || error.message || String(error);
+        console.error('Error generating image prompt with LLM:', message);
+        console.error(error)
         // Fallback to the user prompt if LLM fails
         const fallbackPrompt = typeof prompts?.generationPrompt === 'string'
             ? prompts.generationPrompt


### PR DESCRIPTION
I wrote on the discord `#help` channel because my scenery and items images were showing only the background, and in the terminal I saw prompt generation was failing.

Turns out it was because when recreating my config I had the model accidentally set to `z-ai/GLM-4.6` instead of `glm-4.6` with NanoGPT as provider and somehow this broke only those things while the main game worked.

So this change will make the terminal show the actual error message from the API (in my case: "Model not supported") which helped me understand what was wrong